### PR TITLE
Make sure system sqlite library is used for all mer builds.

### DIFF
--- a/embedding/embedlite/config/mozconfig.merqtxulrunner
+++ b/embedding/embedlite/config/mozconfig.merqtxulrunner
@@ -13,6 +13,7 @@ export CXXFLAGS="$CXXFLAGS -DUSE_ANDROID_OMTC_HACKS=1 "
 ac_add_options --prefix=/usr
 
 ac_add_options --with-system-jpeg
+ac_add_options --enable-system-sqlite
 
 ac_add_options --with-gl-provider=EGL
 

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -115,7 +115,6 @@ echo "export CXXFLAGS=\"\$CXXFLAGS -fuse-ld=gold \"" >> mozconfig
 echo "export LD=ld.gold" >> mozconfig
 echo "ac_add_options --disable-tests" >> mozconfig
 echo "ac_add_options --enable-system-hunspell" >> mozconfig
-echo "ac_add_options --enable-system-sqlite" >> mozconfig
 echo "ac_add_options --enable-libproxy" >> mozconfig
 echo "ac_add_options --enable-jemalloc" >> mozconfig
 echo "ac_add_options --disable-strip" >> mozconfig


### PR DESCRIPTION
Previously the option was set only if the package was build via
rpmbuild. It was not passed when the code was build manually or through
xulrunner-packaging build.sh script. Since Mer builds currently don't
work when using preloaded sqlite let's move the option to the Mer config
file.
