### PR TITLE
Make CompositorOGL::{Pause|Resume} available in EmbedLite.

### DIFF
--- a/gfx/gl/GLContextProviderEGL.cpp
+++ b/gfx/gl/GLContextProviderEGL.cpp
@@ -416,7 +416,13 @@ GLContextEGL::IsCurrent() {
 bool
 GLContextEGL::RenewSurface() {
     if (!mOwnsContext) {
+#ifdef MOZ_WIDGET_QT
+        mSurface = sEGLLibrary.fGetCurrentSurface(LOCAL_EGL_DRAW);
+        MOZ_ASSERT(mSurface != EGL_NO_SURFACE);
+        return MakeCurrent(true);
+#else
         return false;
+#endif
     }
 #ifndef MOZ_WIDGET_ANDROID
     MOZ_CRASH("unimplemented");

--- a/gfx/layers/opengl/CompositorOGL.cpp
+++ b/gfx/layers/opengl/CompositorOGL.cpp
@@ -1392,7 +1392,7 @@ CompositorOGL::CopyToTarget(DrawTarget *aTarget, const gfx::Matrix& aTransform)
 void
 CompositorOGL::Pause()
 {
-#ifdef MOZ_WIDGET_ANDROID
+#if defined(MOZ_WIDGET_ANDROID) || defined(MOZ_WIDGET_QT)
   if (!gl() || gl()->IsDestroyed())
     return;
 
@@ -1404,7 +1404,7 @@ CompositorOGL::Pause()
 bool
 CompositorOGL::Resume()
 {
-#ifdef MOZ_WIDGET_ANDROID
+#if defined(MOZ_WIDGET_ANDROID) || defined(MOZ_WIDGET_QT)
   if (!gl() || gl()->IsDestroyed())
     return false;
 


### PR DESCRIPTION
CompositorOGL's Pause and Resule functions are called from EmbedLiteView
SuspendRendering/ResumeRendering. If two different views share the same
surface we want to make sure that only currently visible view paints
it's content to it. Unfortunately due to current dummy implementation of
CompositorOGL::{Pause|Resume} the
EmbedLiteView::{SuspendRendering|ResumeRendering} did not actually do
anything. This patch fixes this by exposing android implementation also
for QT/EmbedLite gecko port.

This fixes JB#28807.
