### PR TITLE
[rpm] Update external window rendering patch JB#28807

### DIFF
--- a/rpm/0016-Enable-external-window-usage.patch
+++ b/rpm/0016-Enable-external-window-usage.patch
@@ -1,40 +1,66 @@
-From 2b29801ed614eaf08fd028cda6918c42b80577e7 Mon Sep 17 00:00:00 2001
+From 8ad160efe3593ae7f3465c25def24a0b0dd8ca54 Mon Sep 17 00:00:00 2001
 From: Dmitry Rozhkov <dmitry.rozhkov@jolla.com>
 Date: Mon, 11 May 2015 15:27:51 +0300
-Subject: [PATCH 16/16] Enable external window usage
+Subject: [PATCH 16/18] Enable external window usage
 
 ---
- gfx/gl/GLContextProviderEGL.cpp     |  4 ++++
- gfx/layers/opengl/CompositorOGL.cpp | 11 +++++++++++
- 2 files changed, 15 insertions(+)
+ gfx/gl/GLContextProviderEGL.cpp     | 15 ++++++++++++++-
+ gfx/layers/opengl/CompositorOGL.cpp | 20 +++++++++++++++++---
+ gfx/thebes/gfxPrefs.h               |  1 +
+ 3 files changed, 32 insertions(+), 4 deletions(-)
 
 diff --git a/gfx/gl/GLContextProviderEGL.cpp b/gfx/gl/GLContextProviderEGL.cpp
-index e6d89bf..417bd4e 100644
+index e6d89bf..7975a3b 100644
 --- a/gfx/gl/GLContextProviderEGL.cpp
 +++ b/gfx/gl/GLContextProviderEGL.cpp
-@@ -700,6 +700,10 @@ GLContextProviderEGL::CreateWrappingExisting(void* aContext, void* aSurface)
+@@ -101,6 +101,7 @@ public:
+ #include "gfxFailure.h"
+ #include "gfxASurface.h"
+ #include "gfxPlatform.h"
++#include "gfxPrefs.h"
+ #include "GLContextProvider.h"
+ #include "GLLibraryEGL.h"
+ #include "TextureImageEGL.h"
+@@ -416,7 +417,13 @@ GLContextEGL::IsCurrent() {
+ bool
+ GLContextEGL::RenewSurface() {
+     if (!mOwnsContext) {
+-        return false;
++        if (gfxPrefs::UseExternalWindow()) {
++            mSurface = sEGLLibrary.fGetCurrentSurface(LOCAL_EGL_DRAW);
++            MOZ_ASSERT(mSurface != EGL_NO_SURFACE);
++            return MakeCurrent(true);
++        } else {
++            return false;
++        }
+     }
+ #ifndef MOZ_WIDGET_ANDROID
+     MOZ_CRASH("unimplemented");
+@@ -700,6 +707,12 @@ GLContextProviderEGL::CreateWrappingExisting(void* aContext, void* aSurface)
          return nullptr;
      }
-
-+    // TODO as soon context and surface guaranteed to be non-null
-+    aSurface = aSurface ? aSurface : sEGLLibrary.fGetCurrentSurface(LOCAL_EGL_DRAW);
-+    aContext = aContext ? aContext : sEGLLibrary.fGetCurrentContext();
+ 
++    if (gfxPrefs::UseExternalWindow()) {
++        // TODO as soon context and surface guaranteed to be non-null
++        aSurface = aSurface ? aSurface : sEGLLibrary.fGetCurrentSurface(LOCAL_EGL_DRAW);
++        aContext = aContext ? aContext : sEGLLibrary.fGetCurrentContext();
++    }
 +
      if (aContext && aSurface) {
          SurfaceCaps caps = SurfaceCaps::Any();
          EGLConfig config = EGL_NO_CONFIG;
 diff --git a/gfx/layers/opengl/CompositorOGL.cpp b/gfx/layers/opengl/CompositorOGL.cpp
-index 0b85a2d..6ea17ef 100644
+index c12d381..781dcfb 100644
 --- a/gfx/layers/opengl/CompositorOGL.cpp
 +++ b/gfx/layers/opengl/CompositorOGL.cpp
 @@ -185,6 +185,17 @@ CompositorOGL::CreateContext()
    }
  #endif
-
+ 
 +  // If widget has active GL context then we can try to wrap it into Moz GL Context.
 +  // Allow widget to create opengl context for the compositor thread and
 +  // using surface of an external window.
-+  if (PR_GetEnv("MOZ_USE_EXTERNAL_WINDOW") && mWidget->HasGLContext()) {
++  if (gfxPrefs::UseExternalWindow() && mWidget->HasGLContext()) {
 +    context = GLContextProvider::CreateWrappingExisting(nullptr, nullptr);
 +    if (!context || !context->Init()) {
 +      NS_WARNING("Failed to create embedded context");
@@ -45,5 +71,41 @@ index 0b85a2d..6ea17ef 100644
    // Allow to create offscreen GL context for main Layer Manager
    if (!context && PR_GetEnv("MOZ_LAYERS_PREFER_OFFSCREEN")) {
      SurfaceCaps caps = SurfaceCaps::ForRGB();
---
-1.9.1
+@@ -1392,8 +1403,8 @@ CompositorOGL::CopyToTarget(DrawTarget *aTarget, const gfx::Matrix& aTransform)
+ void
+ CompositorOGL::Pause()
+ {
+-#ifdef MOZ_WIDGET_ANDROID
+-  if (!gl() || gl()->IsDestroyed())
++#if defined(MOZ_WIDGET_ANDROID) || defined(MOZ_WIDGET_QT)
++  if (!gl() || gl()->IsDestroyed() || !gfxPrefs::UseExternalWindow())
+     return;
+ 
+   // ReleaseSurface internally calls MakeCurrent.
+@@ -1404,7 +1415,10 @@ CompositorOGL::Pause()
+ bool
+ CompositorOGL::Resume()
+ {
+-#ifdef MOZ_WIDGET_ANDROID
++#if defined(MOZ_WIDGET_ANDROID) || defined(MOZ_WIDGET_QT)
++  if (!gfxPrefs::UseExternalWindow())
++    return true;
++
+   if (!gl() || gl()->IsDestroyed())
+     return false;
+ 
+diff --git a/gfx/thebes/gfxPrefs.h b/gfx/thebes/gfxPrefs.h
+index af0175b..40e9935 100644
+--- a/gfx/thebes/gfxPrefs.h
++++ b/gfx/thebes/gfxPrefs.h
+@@ -138,6 +138,7 @@ private:
+   DECL_GFX_PREF(Once, "gfx.canvas.skiagl.cache-items",         CanvasSkiaGLCacheItems, int32_t, 256);
+ 
+   DECL_GFX_PREF(Once, "gfx.compositor.clear-context",          ClearCompoisitorContext, bool, true);
++  DECL_GFX_PREF(Once, "gfx.compositor.external-window",        UseExternalWindow, bool, false);
+ 
+   DECL_GFX_PREF(Live, "gfx.color_management.enablev4",         CMSEnableV4, bool, false);
+   DECL_GFX_PREF(Live, "gfx.color_management.mode",             CMSMode, int32_t,-1);
+-- 
+2.3.6
+


### PR DESCRIPTION
CompositorOGL's Pause and Resule functions are called fromEmbedLiteView
SuspendRendering/ResumeRendering. If two different views share the same
surface we want to make sure that only currently visible view paints
it's content to it. Unfortunately due to current dummy implementation of
CompositorOGL::{Pause|Resume} the
EmbedLiteView::{SuspendRendering|ResumeRendering} did not actually do
anything. This patch fixes this by exposing android implementation also
for QT/EmbedLite gecko port.
