### PR TITLE
[spec] Don't generate "Provides:" for private libs (JB#28812)

### DIFF
--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -1,4 +1,5 @@
 %define greversion 31.7.0
+%global __provides_exclude_from %{_libdir}/%{name}-%{greversion}/.*\.so
 
 Name:       xulrunner-qt5
 Summary:    XUL runner


### PR DESCRIPTION
This now only generates the package's provides, and nothing else:

```
% rpm -q --provides -p ~/xulrunner-qt5-31.7.0.8+jb28812.20150519090044.3.g66846fa-10.21.2.jolla.armv7hl.rpm
warning: /home/nemo/xulrunner-qt5-31.7.0.8+jb28812.20150519090044.3.g66846fa-10.21.2.jolla.armv7hl.rpm: Header V3 DSA/SHA1 Signature, key ID f2633ee0: NOKEY
xulrunner-qt5 = 31.7.0.8+jb28812.20150519090044.3.g66846fa-10.21.2.jolla
xulrunner-qt5(armv7hl-32) = 31.7.0.8+jb28812.20150519090044.3.g66846fa-10.21.2.jolla
```
