### PR TITLE
[embedlite] Expose an API for clearing gecko compositing surface. JB#…

### DIFF
--- a/embedding/embedlite/EmbedLiteView.cpp
+++ b/embedding/embedlite/EmbedLiteView.cpp
@@ -304,6 +304,13 @@ EmbedLiteView::ScheduleUpdate()
 }
 
 void
+EmbedLiteView::ClearContent(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+{
+  NS_ENSURE_TRUE(mViewImpl, );
+  mViewImpl->ClearContent(NS_RGBA(r, g, b, a));
+}
+
+void
 EmbedLiteView::SuspendRendering()
 {
   NS_ENSURE_TRUE(mViewImpl, );

--- a/embedding/embedlite/EmbedLiteView.h
+++ b/embedding/embedlite/EmbedLiteView.h
@@ -133,6 +133,10 @@ public:
   virtual void SetScreenRotation(mozilla::ScreenRotation rotation);
 
   virtual void ScheduleUpdate();
+  // Clear the content of the view compositing surface with a given color.
+  // Calling the function before the view has created it's compositor
+  // (EmbedLiteViewListener::RequestCurrentGLContext was called) is a no-op.
+  virtual void ClearContent(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 
   // Scripting Interface, allow to extend embedding API by creating
   // child js scripts and messaging interface.

--- a/embedding/embedlite/embedhelpers/EmbedLiteViewIface.idl
+++ b/embedding/embedlite/embedhelpers/EmbedLiteViewIface.idl
@@ -26,7 +26,7 @@ class nsString;
 [ptr] native PlatformImage(void);
 [ptr] native buffer(unsigned char);
 
-[scriptable, uuid(6d7750f8-e028-4445-a0cb-d9ce28fb03dd)]
+[scriptable, uuid(9aab16e8-1992-11e5-b60b-1697f925ec7b)]
 interface EmbedLiteViewIface
 {
     void RenderToImage(in buffer aData, in int32_t aWidth, in int32_t aHeigth, in int32_t aStride, in int32_t aDepth);
@@ -47,4 +47,5 @@ interface EmbedLiteViewIface
     void GetPlatformImage(out PlatformImage aImage, out int32_t aWidth, out int32_t aHeight);
     void SuspendRendering();
     void ResumeRendering();
+    void ClearContent(in uint32_t aColor);
 };

--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
@@ -16,6 +16,9 @@
 
 namespace mozilla {
 
+namespace gl {
+class GLContext;
+}
 namespace layers {
 class LayerManagerComposite;
 }
@@ -36,13 +39,13 @@ public:
   void SetScreenRotation(const mozilla::ScreenRotation& rotation);
   void SetClipping(const gfxRect& aClipRect);
   void* GetPlatformImage(int* width, int* height);
-  virtual void SuspendRendering();
-  virtual void ResumeRendering();
-
-  virtual bool RequestGLContext();
+  void SuspendRendering();
+  void ResumeRendering();
+  bool RequestGLContext();
 
   void DrawWindowUnderlay(mozilla::layers::LayerManagerComposite *aManager, nsIntRect aRect);
   void DrawWindowOverlay(mozilla::layers::LayerManagerComposite *aManager, nsIntRect aRect);
+  void ClearCompositorSurface(nscolor);
 
 protected:
   virtual ~EmbedLiteCompositorParent();
@@ -57,6 +60,8 @@ private:
   void PrepareOffscreen();
   bool Invalidate();
   void UpdateTransformState();
+
+  static void ClearCompositorSurfaceImpl(mozilla::gl::GLContext*, nscolor);
 
   uint32_t mId;
   gfx::Matrix mWorldTransform;

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.cpp
@@ -18,7 +18,6 @@
 
 using namespace mozilla::gfx;
 using namespace mozilla::gl;
-
 using namespace mozilla::layers;
 using namespace mozilla::widget;
 
@@ -445,6 +444,15 @@ EmbedLiteViewThreadParent::SuspendRendering()
     mCompositor->SuspendRendering();
   }
 
+  return NS_OK;
+}
+
+NS_IMETHODIMP
+EmbedLiteViewThreadParent::ClearContent(nscolor color)
+{
+  if (mCompositor) {
+    mCompositor->ClearCompositorSurface(color);
+  }
   return NS_OK;
 }
 


### PR DESCRIPTION
…29995

In new sailfish-browser rendering architecture when all the tabs share
the same compositing surface we need the ability to clear it in cerain
cases. One example is when all the tabs get closed. By default this
would mean that the content of the last rendered active page will ocupy
the compositing surface until a new tab is created and some page is
loaded into it. This is rather bad from user experience POV. The problem
could theoretically be solved by clearing the surface on the browser
side, but since gecko draws to it from a dedicated compositor thread it
would require an additional synchronization mechanism to be introduced.

This patch takes a simplier approach by introducing a dedicated API for
clearing view compositing surface with a given color. This should allow
any application to clear the compositing surface whenever it wants
provided the compositor for the view has been initialized. The function
will execute necessary GL commands on an appropriate gecko thread.
