### PR TITLE
[xulrunner] Generalize and improve external gl context handling. Contributes to JB#30162.

### DIFF
--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -82,6 +82,10 @@ pref("embedlite.azpc.json.longtap", false);
 pref("embedlite.azpc.json.scroll", false);
 // Make gecko compositor use GL context/surface provided by the application.
 pref("embedlite.compositor.external_gl_context", false);
+// Request the application to create GLContext for the compositor as
+// soon as the top level PuppetWidget is creted for the view. Setting
+// this pref only makes sense when using external compositor gl context.
+pref("embedlite.compositor.request_external_gl_context_early", false);
 pref("extensions.update.enabled", false);
 pref("toolkit.storage.synchronous", 0);
 /* new html5 forms */

--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -80,6 +80,8 @@ pref("embedlite.azpc.json.singletap", false);
 pref("embedlite.azpc.json.doubletap", false);
 pref("embedlite.azpc.json.longtap", false);
 pref("embedlite.azpc.json.scroll", false);
+// Make gecko compositor use GL context/surface provided by the application.
+pref("embedlite.compositor.external_gl_context", false);
 pref("extensions.update.enabled", false);
 pref("toolkit.storage.synchronous", 0);
 /* new html5 forms */

--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
@@ -310,13 +310,6 @@ EmbedLiteCompositorParent::ResumeRendering()
   CompositorParent::ScheduleResumeOnCompositorThread(mLastViewSize.width, mLastViewSize.height);
 }
 
-bool
-EmbedLiteCompositorParent::RequestGLContext()
-{
-  EmbedLiteView* view = EmbedLiteApp::GetInstance()->GetViewByID(mId);
-  return view ? view->GetListener()->RequestCurrentGLContext() : false;
-}
-
 void mozilla::embedlite::EmbedLiteCompositorParent::DrawWindowUnderlay(LayerManagerComposite *aManager, nsIntRect aRect)
 {
   EmbedLiteView* view = EmbedLiteApp::GetInstance()->GetViewByID(mId);

--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
@@ -41,7 +41,6 @@ public:
   void* GetPlatformImage(int* width, int* height);
   void SuspendRendering();
   void ResumeRendering();
-  bool RequestGLContext();
 
   void DrawWindowUnderlay(mozilla::layers::LayerManagerComposite *aManager, nsIntRect aRect);
   void DrawWindowOverlay(mozilla::layers::LayerManagerComposite *aManager, nsIntRect aRect);

--- a/embedding/embedlite/embedthread/EmbedLitePuppetWidget.cpp
+++ b/embedding/embedlite/embedthread/EmbedLitePuppetWidget.cpp
@@ -50,6 +50,7 @@ const size_t EmbedLitePuppetWidget::kMaxDimension = 4000;
 static nsTArray<EmbedLitePuppetWidget*> gTopLevelWindows;
 static bool sFailedToCreateGLContext = false;
 static bool sUseExternalGLContext = false;
+static bool sRequestGLContextEarly = false;
 
 NS_IMPL_ISUPPORTS_INHERITED(EmbedLitePuppetWidget, nsBaseWidget,
                             nsISupportsWeakReference)
@@ -100,6 +101,8 @@ EmbedLitePuppetWidget::EmbedLitePuppetWidget(EmbedLiteViewThreadChild* aEmbed, u
   if (!prefsInitialized) {
     Preferences::AddBoolVarCache(&sUseExternalGLContext,
         "embedlite.compositor.external_gl_context", false);
+    Preferences::AddBoolVarCache(&sRequestGLContextEarly,
+        "embedlite.compositor.request_external_gl_context_early", false);
     prefsInitialized = true;
   }
 }
@@ -151,6 +154,13 @@ EmbedLitePuppetWidget::Create(nsIWidget*        aParent,
   if (IsTopLevel()) {
     LOGT("Append this to toplevel windows:%p", this);
     gTopLevelWindows.AppendElement(this);
+  }
+
+  if (sUseExternalGLContext && sRequestGLContextEarly) {
+    // GetPlatform() should create compositor loop if it doesn't exist, yet.
+    gfxPlatform::GetPlatform();
+    CompositorParent::CompositorLoop()->PostTask(FROM_HERE,
+        NewRunnableFunction(&CreateGLContextEarly, mId));
   }
 
   return NS_OK;
@@ -456,6 +466,20 @@ EmbedLitePuppetWidget::GetGLContext() const
     }
   }
   return nullptr;
+}
+
+void
+EmbedLitePuppetWidget::CreateGLContextEarly(uint32_t aViewId)
+{
+  LOGT("ViewId:%u", aViewId);
+  MOZ_ASSERT(CompositorParent::IsInCompositorThread());
+  MOZ_ASSERT(sRequestGLContextEarly);
+  EmbedLiteView* view = EmbedLiteApp::GetInstance()->GetViewByID(aViewId);
+  if (view) {
+    view->GetListener()->RequestCurrentGLContext();
+  } else {
+    NS_WARNING("Trying to early create GL context for non existing view!");
+  }
 }
 
 LayerManager*

--- a/embedding/embedlite/embedthread/EmbedLitePuppetWidget.cpp
+++ b/embedding/embedlite/embedthread/EmbedLitePuppetWidget.cpp
@@ -19,12 +19,15 @@
 #include "mozilla/layers/ImageBridgeChild.h"
 #include "mozilla/ipc/MessageChannel.h"
 #include "EmbedLitePuppetWidget.h"
+#include "EmbedLiteView.h"
 #include "nsIWidgetListener.h"
 
 #include "Layers.h"
 #include "BasicLayers.h"
 #include "ClientLayerManager.h"
 #include "GLContextProvider.h"
+#include "GLContext.h"
+#include "GLLibraryEGL.h"
 #include "EmbedLiteCompositorParent.h"
 #include "mozilla/Preferences.h"
 #include "EmbedLiteApp.h"
@@ -32,6 +35,7 @@
 #include "mozilla/unused.h"
 
 using namespace mozilla::dom;
+using namespace mozilla::gl;
 using namespace mozilla::hal;
 using namespace mozilla::layers;
 using namespace mozilla::widget;
@@ -45,6 +49,7 @@ const size_t EmbedLitePuppetWidget::kMaxDimension = 4000;
 
 static nsTArray<EmbedLitePuppetWidget*> gTopLevelWindows;
 static bool sFailedToCreateGLContext = false;
+static bool sUseExternalGLContext = false;
 
 NS_IMPL_ISUPPORTS_INHERITED(EmbedLitePuppetWidget, nsBaseWidget,
                             nsISupportsWeakReference)
@@ -91,6 +96,12 @@ EmbedLitePuppetWidget::EmbedLitePuppetWidget(EmbedLiteViewThreadChild* aEmbed, u
 {
   MOZ_COUNT_CTOR(EmbedLitePuppetWidget);
   LOGT("this:%p", this);
+  static bool prefsInitialized = false;
+  if (!prefsInitialized) {
+    Preferences::AddBoolVarCache(&sUseExternalGLContext,
+        "embedlite.compositor.external_gl_context", false);
+    prefsInitialized = true;
+  }
 }
 
 EmbedLitePuppetWidget::~EmbedLitePuppetWidget()
@@ -264,6 +275,10 @@ EmbedLitePuppetWidget::GetNativeData(uint32_t aDataType)
       LOGW("aDataType:%i\n", __LINE__, aDataType);
       return (void*)nullptr;
     }
+    case NS_NATIVE_OPENGL_CONTEXT: {
+      MOZ_ASSERT(!GetParent());
+      return GetGLContext();
+    }
     case NS_NATIVE_WINDOW:
     case NS_NATIVE_DISPLAY:
     case NS_NATIVE_PLUGIN_PORT:
@@ -418,6 +433,31 @@ EmbedLitePuppetWidget::ViewIsValid()
   return EmbedLiteApp::GetInstance()->GetViewByID(mId) != nullptr;
 }
 
+mozilla::gl::GLContext*
+EmbedLitePuppetWidget::GetGLContext() const
+{
+  LOGT("this:%p, UseExternalContext:%d", this, sUseExternalGLContext);
+  if (sUseExternalGLContext) {
+    if (!sEGLLibrary.EnsureInitialized()) {
+      return nullptr;
+    }
+
+    EmbedLiteView* view = EmbedLiteApp::GetInstance()->GetViewByID(mId);
+    if (view && view->GetListener()->RequestCurrentGLContext()) {
+      void* surface = sEGLLibrary.fGetCurrentSurface(LOCAL_EGL_DRAW);
+      void* context = sEGLLibrary.fGetCurrentContext();
+      nsRefPtr<GLContext> mozContext = GLContextProvider::CreateWrappingExisting(context, surface);
+      if (!mozContext->Init()) {
+        return nullptr;
+      }
+      return mozContext.forget().take();
+    } else {
+      NS_ERROR("Embedder wants to use external GL context without actually providing it!");
+    }
+  }
+  return nullptr;
+}
+
 LayerManager*
 EmbedLitePuppetWidget::GetLayerManager(PLayerTransactionChild* aShadowManager,
                                        LayersBackend aBackendHint,
@@ -561,14 +601,6 @@ nsIntRect
 EmbedLitePuppetWidget::GetNaturalBounds()
 {
   return nsIntRect();
-}
-
-bool
-EmbedLitePuppetWidget::HasGLContext()
-{
-  EmbedLiteCompositorParent* parent =
-    static_cast<EmbedLiteCompositorParent*>(mCompositorParent.get());
-  return parent->RequestGLContext();
 }
 
 void

--- a/embedding/embedlite/embedthread/EmbedLitePuppetWidget.h
+++ b/embedding/embedlite/embedthread/EmbedLitePuppetWidget.h
@@ -24,6 +24,11 @@
 #include "EmbedLiteViewThreadChild.h"
 
 namespace mozilla {
+
+namespace gl {
+class GLContext;
+}
+
 namespace embedlite {
 
 class EmbedLitePuppetWidget : public nsBaseWidget,
@@ -148,7 +153,6 @@ public:
   virtual void CreateCompositor(int aWidth, int aHeight);
   virtual void CreateCompositor();
   virtual nsIntRect GetNaturalBounds();
-  virtual bool HasGLContext();
 
   /**
    * Called before the LayerManager draws the layer tree.
@@ -176,6 +180,7 @@ protected:
 private:
   nsresult Paint();
   bool ViewIsValid();
+  mozilla::gl::GLContext* GetGLContext() const;
 
   EmbedLitePuppetWidget* TopWindow();
   bool IsTopLevel();

--- a/embedding/embedlite/embedthread/EmbedLitePuppetWidget.h
+++ b/embedding/embedlite/embedthread/EmbedLitePuppetWidget.h
@@ -181,6 +181,7 @@ private:
   nsresult Paint();
   bool ViewIsValid();
   mozilla::gl::GLContext* GetGLContext() const;
+  static void CreateGLContextEarly(uint32_t aViewId);
 
   EmbedLitePuppetWidget* TopWindow();
   bool IsTopLevel();

--- a/gfx/layers/opengl/CompositorOGL.cpp
+++ b/gfx/layers/opengl/CompositorOGL.cpp
@@ -178,6 +178,13 @@ CompositorOGL::CreateContext()
 {
   nsRefPtr<GLContext> context;
 
+  // Used by mock widget to create an offscreen context
+  void* widgetOpenGLContext = mWidget->GetNativeData(NS_NATIVE_OPENGL_CONTEXT);
+  if (widgetOpenGLContext) {
+    GLContext* alreadyRefed = reinterpret_cast<GLContext*>(widgetOpenGLContext);
+    return already_AddRefed<GLContext>(alreadyRefed);
+  }
+
 #ifdef XP_WIN
   if (PR_GetEnv("MOZ_LAYERS_PREFER_EGL")) {
     printf_stderr("Trying GL layers...\n");

--- a/rpm/0016-Implement-support-for-Pausing-Resuming-OpenGL-compos.patch
+++ b/rpm/0016-Implement-support-for-Pausing-Resuming-OpenGL-compos.patch
@@ -1,17 +1,25 @@
-From 5b134026da5ab17ed12277e20d3469871a20379c Mon Sep 17 00:00:00 2001
-From: Dmitry Rozhkov <dmitry.rozhkov@jolla.com>
-Date: Mon, 11 May 2015 15:27:51 +0300
-Subject: [PATCH 16/17] Enable external window usage
+From 3d6756c360598fee4c3558129d2ff481c7b0ad90 Mon Sep 17 00:00:00 2001
+From: Piotr Tworek <piotr.tworek@jollamobile.com>
+Date: Wed, 24 Jun 2015 13:10:49 +0200
+Subject: [PATCH 16/17] Implement support for Pausing/Resuming OpenGL
+ compositing process.
 
+This patch implements the necessary bits to allowing multiple CompositorOGL
+instances to share the same compsiting surface. Without the patch
+CompositorOGL::{Pause|Resume} are basically no-ops in embedlite builds.
+
+It's not clear if this patch is needed for gecko v38. Contrary to gecko v31
+::Pause and ::Resume calls in v38 are actually implemented for non Android
+platforms.
 ---
- gfx/gl/GLContextProviderEGL.cpp     | 15 ++++++++++-
- gfx/layers/opengl/CompositorOGL.cpp | 51 ++++++++++++++++++++++++++++++++++---
+ gfx/gl/GLContextProviderEGL.cpp     |  9 ++++++++-
+ gfx/layers/opengl/CompositorOGL.cpp | 40 ++++++++++++++++++++++++++++++++++---
  gfx/layers/opengl/CompositorOGL.h   |  2 ++
  gfx/thebes/gfxPrefs.h               |  1 +
- 4 files changed, 65 insertions(+), 4 deletions(-)
+ 4 files changed, 48 insertions(+), 4 deletions(-)
 
 diff --git a/gfx/gl/GLContextProviderEGL.cpp b/gfx/gl/GLContextProviderEGL.cpp
-index e6d89bf..7975a3b 100644
+index e6d89bf..867ad65 100644
 --- a/gfx/gl/GLContextProviderEGL.cpp
 +++ b/gfx/gl/GLContextProviderEGL.cpp
 @@ -101,6 +101,7 @@ public:
@@ -37,21 +45,8 @@ index e6d89bf..7975a3b 100644
      }
  #ifndef MOZ_WIDGET_ANDROID
      MOZ_CRASH("unimplemented");
-@@ -700,6 +707,12 @@ GLContextProviderEGL::CreateWrappingExisting(void* aContext, void* aSurface)
-         return nullptr;
-     }
- 
-+    if (gfxPrefs::UseExternalWindow()) {
-+        // TODO as soon context and surface guaranteed to be non-null
-+        aSurface = aSurface ? aSurface : sEGLLibrary.fGetCurrentSurface(LOCAL_EGL_DRAW);
-+        aContext = aContext ? aContext : sEGLLibrary.fGetCurrentContext();
-+    }
-+
-     if (aContext && aSurface) {
-         SurfaceCaps caps = SurfaceCaps::Any();
-         EGLConfig config = EGL_NO_CONFIG;
 diff --git a/gfx/layers/opengl/CompositorOGL.cpp b/gfx/layers/opengl/CompositorOGL.cpp
-index 2c5f79f..62216c7 100644
+index 2c5f79f..72812c4 100644
 --- a/gfx/layers/opengl/CompositorOGL.cpp
 +++ b/gfx/layers/opengl/CompositorOGL.cpp
 @@ -161,6 +161,7 @@ CompositorOGL::CompositorOGL(nsIWidget *aWidget, int aSurfaceWidth,
@@ -62,25 +57,7 @@ index 2c5f79f..62216c7 100644
    , mHeight(0)
  {
    MOZ_COUNT_CTOR(CompositorOGL);
-@@ -185,6 +186,17 @@ CompositorOGL::CreateContext()
-   }
- #endif
- 
-+  // If widget has active GL context then we can try to wrap it into Moz GL Context.
-+  // Allow widget to create opengl context for the compositor thread and
-+  // using surface of an external window.
-+  if (gfxPrefs::UseExternalWindow() && mWidget->HasGLContext()) {
-+    context = GLContextProvider::CreateWrappingExisting(nullptr, nullptr);
-+    if (!context || !context->Init()) {
-+      NS_WARNING("Failed to create embedded context");
-+      context = nullptr;
-+    }
-+  }
-+
-   // Allow to create offscreen GL context for main Layer Manager
-   if (!context && PR_GetEnv("MOZ_LAYERS_PREFER_OFFSCREEN")) {
-     SurfaceCaps caps = SurfaceCaps::ForRGB();
-@@ -1404,28 +1416,61 @@ CompositorOGL::CopyToTarget(DrawTarget *aTarget, const gfx::Matrix& aTransform)
+@@ -1404,28 +1405,61 @@ CompositorOGL::CopyToTarget(DrawTarget *aTarget, const gfx::Matrix& aTransform)
  void
  CompositorOGL::Pause()
  {

--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -24,7 +24,7 @@ Patch12:    0012-Don-t-zoom-video-when-in-full-screen.patch
 Patch13:    0013-Disallow-image-locking-no-matter-what.patch
 Patch14:    0014-Notify-UI-about-change-in-composition-bounds.-jb1799.patch
 Patch15:    0015-limit-surface-area-rather-than-width-and-height.patch
-Patch16:    0016-Enable-external-window-usage.patch
+Patch16:    0016-Implement-support-for-Pausing-Resuming-OpenGL-compos.patch
 Patch17:    0017-Add-Intel-Bay-Trail-GL-specific-workarounds.-JB-2967.patch
 BuildRequires:  pkgconfig(Qt5Quick)
 BuildRequires:  pkgconfig(Qt5Network)

--- a/widget/nsIWidget.h
+++ b/widget/nsIWidget.h
@@ -88,6 +88,7 @@ typedef void* nsNativeWidget;
 // Has to match to NPNVnetscapeWindow, and shareable across processes
 // HWND on Windows and XID on X11
 #define NS_NATIVE_SHAREABLE_WINDOW 11
+#define NS_NATIVE_OPENGL_CONTEXT   12
 #ifdef XP_MACOSX
 #define NS_NATIVE_PLUGIN_PORT_QD    100
 #define NS_NATIVE_PLUGIN_PORT_CG    101


### PR DESCRIPTION
This patch set grew a little bit bigger than originally anticipated, but I believe it's a move into right direction. Right now the whole external rendering feature we have in embedlite_31 is only partially upstream. All the qmozemed bits are there, but a the main gecko part sits as a patch in nemo's embedlite_31 rpm directory. As a result the whole external window rendering codepath is not actually usable with upstream embedlite. This patchset aims to fix this while also taking care of some bugs like JB#30162.

First in v38 an additional codepath for obtaining external GL context was introduced into CompositorOGL. Since this piece of code is something that we can utilize the fist patch backports it to v31. 

The next 2 patches split and re-factor the original external window patch.. With the help of the first patch the actual part needed to obtain GL context and surface from the platform can be placed entirely in embedlite layer. This is the goal of the second part in the series.

The compositor pausing/resuming part of the external window patch is left unchanged and is still provided as an external patch applied via spec. This part of the feature is not essential to get the rendering working and since the codepaths it affects have been changed in v38 it's possible it won't even be needed.

The last part of the patch-set implements support for requesting GL context from the application early during view creation. In normal gecko the compositor creates it's GL context after the layout engine performed the first paint of the rendered content. With the patch applied and embedlite.compositor.request_external_gl_context_early pref set to true, the engine will request the application to create it's compositor context as soon as first EmbedLitePuppetWidget is created.

The 2nd and 4th patch are suitable for pushing into embedlite_38 branch and with some small additional bug-fixes (not related to this patch) make it possible to run sailfish-browser from next branch with gecko 38.
