### PR TITLE
[xulrunner] Add an API for posting external tasks to compositor thread. Contributes to JB#30162.

### DIFF
--- a/embedding/embedlite/EmbedLiteApp.cpp
+++ b/embedding/embedlite/EmbedLiteApp.cpp
@@ -13,6 +13,7 @@
 #include "base/message_loop.h"               // for MessageLoop
 
 #include "mozilla/embedlite/EmbedLiteAPI.h"
+#include "mozilla/layers/CompositorParent.h"
 
 #include "EmbedLiteUILoop.h"
 #include "EmbedLiteSubThread.h"
@@ -108,6 +109,27 @@ EmbedLiteApp::PostTask(EMBEDTaskCallback callback, void* userData, int timeout)
     mUILoop->PostDelayedTask(FROM_HERE, newTask, timeout);
   } else {
     mUILoop->PostTask(FROM_HERE, newTask);
+  }
+
+  return (void*)newTask;
+}
+
+void*
+EmbedLiteApp::PostCompositorTask(EMBEDTaskCallback callback, void* userData, int timeout)
+{
+  if (!mozilla::layers::CompositorParent::CompositorLoop()) {
+    // Can't post compositor task if gecko compositor thread has not been initialized, yet.
+    return nullptr;
+  }
+
+  CancelableTask* newTask = NewRunnableFunction(callback, userData);
+  MessageLoop* compositorLoop = mozilla::layers::CompositorParent::CompositorLoop();
+  MOZ_ASSERT(compositorLoop);
+
+  if (timeout) {
+    compositorLoop->PostDelayedTask(FROM_HERE, newTask, timeout);
+  } else {
+    compositorLoop->PostTask(FROM_HERE, newTask);
   }
 
   return (void*)newTask;

--- a/embedding/embedlite/EmbedLiteApp.h
+++ b/embedding/embedlite/EmbedLiteApp.h
@@ -78,6 +78,7 @@ public:
 
   // Delayed post task helper for delayed functions call in main thread
   virtual void* PostTask(EMBEDTaskCallback callback, void* userData, int timeout = 0);
+  virtual void* PostCompositorTask(EMBEDTaskCallback callback, void* userData, int timeout = 0);
   virtual void CancelTask(void* aTask);
 
   // Setup profile path for embedding, or null if embedding supposed to be profile-less


### PR DESCRIPTION
This is a generic API similar to already available EmbedLiteApp::PostTask.
The main difference is, as the function name suggests,
EmbedLiteApp::PostCompostiorTask schedules the callback function to be
executed on gecko compositor thread. In case the compositor was not yet
created by the engine the function returns nullptr.
