### PR TITLE
[rpm] Make sure xulrunner-qt5 does not depend or provide it's private libs. Contributes to JB#28952.

### DIFF
--- a/rpm/xulrunner-qt5.spec
+++ b/rpm/xulrunner-qt5.spec
@@ -1,5 +1,21 @@
 %define greversion 31.7.0
-%global __provides_exclude_from %{_libdir}/%{name}-%{greversion}/.*[^libmozalloc]\\.so
+
+# Private/bundled libs the final package should not provide or depend on.
+%global privlibs             libfreebl3
+%global privlibs %{privlibs}|libmozalloc
+%global privlibs %{privlibs}|libmozsqlite3
+%global privlibs %{privlibs}|libnspr4
+%global privlibs %{privlibs}|libnss3
+%global privlibs %{privlibs}|libnssdbm3
+%global privlibs %{privlibs}|libnssutil3
+%global privlibs %{privlibs}|libplc4
+%global privlibs %{privlibs}|libplds4
+%global privlibs %{privlibs}|libsmime3
+%global privlibs %{privlibs}|libsoftokn3
+%global privlibs %{privlibs}|libssl3
+
+%global __provides_exclude ^(%{privlibs})\\.so
+%global __requires_exclude ^(%{privlibs})\\.so
 
 Name:       xulrunner-qt5
 Summary:    XUL runner


### PR DESCRIPTION
Xulrunner package bundles libs like nss, nspr, jemalloc, sqlite in it's
private directory. Those bundled libraries are only used by libxul.so so
the final package should not provide them. Also, since the package has
its own copy of the libs it should not depend on external libnss,
libnspr or sqlite3 packages.
