### PR TITLE
[xulrunner] Expose nsIBaseWidget::PreRender in EmbedLite public API. Contributes to JB#31866.

### DIFF
--- a/embedding/embedlite/EmbedLiteView.h
+++ b/embedding/embedlite/EmbedLiteView.h
@@ -75,6 +75,7 @@ public:
 
   // Will be always called from the compositor thread.
   virtual void DrawUnderlay() {}
+  virtual bool PreRender() { return true; }
 
   // Will be always called from the compositor thread.
   virtual void DrawOverlay(const nsIntRect& aRect) {}

--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
@@ -326,6 +326,15 @@ void EmbedLiteCompositorParent::DrawWindowOverlay(LayerManagerComposite *aManage
   }
 }
 
+bool EmbedLiteCompositorParent::PreRender(LayerManagerComposite* aManager)
+{
+  EmbedLiteView* view = EmbedLiteApp::GetInstance()->GetViewByID(mId);
+  if (view) {
+    return view->GetListener()->PreRender();
+  }
+  return true;
+}
+
 void EmbedLiteCompositorParent::ClearCompositorSurface(nscolor aColor)
 {
   CancelCurrentCompositeTask();

--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
@@ -44,6 +44,7 @@ public:
 
   void DrawWindowUnderlay(mozilla::layers::LayerManagerComposite *aManager, nsIntRect aRect);
   void DrawWindowOverlay(mozilla::layers::LayerManagerComposite *aManager, nsIntRect aRect);
+  bool PreRender(layers::LayerManagerComposite* aManager);
   void ClearCompositorSurface(nscolor);
 
 protected:

--- a/embedding/embedlite/embedthread/EmbedLitePuppetWidget.cpp
+++ b/embedding/embedlite/embedthread/EmbedLitePuppetWidget.cpp
@@ -642,5 +642,12 @@ void EmbedLitePuppetWidget::DrawWindowOverlay(LayerManagerComposite *aManager, n
   parent->DrawWindowOverlay(aManager, aRect);
 }
 
+bool EmbedLitePuppetWidget::PreRender(LayerManagerComposite* aManager)
+{
+  EmbedLiteCompositorParent* parent =
+    static_cast<EmbedLiteCompositorParent*>(mCompositorParent.get());
+  return parent->PreRender(aManager);
+}
+
 }  // namespace widget
 }  // namespace mozilla

--- a/embedding/embedlite/embedthread/EmbedLitePuppetWidget.h
+++ b/embedding/embedlite/embedthread/EmbedLitePuppetWidget.h
@@ -171,6 +171,8 @@ public:
    */
   virtual void DrawWindowOverlay(LayerManagerComposite* aManager, nsIntRect aRect);
 
+  virtual bool PreRender(LayerManagerComposite* aManager) override;
+
   NS_IMETHOD         SetParent(nsIWidget* aNewParent);
   virtual nsIWidget *GetParent(void);
 


### PR DESCRIPTION
Per function documentation:
  Called before rendering using OMTC. Returns false when the widget
  is not ready to be rendered (for example while the window is closed).

  Always called from the compositing thread, which may be the main-thread if
  OMTC is not enabled.

With this function we should be able to prevent gecko from drawing
contents for the active view in certain situations. Current use case is
to prevent painting when device screen is turned off.
