### PR TITLE
Add API for setting APZC's DPI

### DIFF
--- a/embedding/embedlite/EmbedLiteView.cpp
+++ b/embedding/embedlite/EmbedLiteView.cpp
@@ -289,6 +289,13 @@ EmbedLiteView::SetViewSize(int width, int height)
 }
 
 void
+EmbedLiteView::SetDPI(const float& dpi)
+{
+  NS_ENSURE_TRUE(mViewImpl, );
+  mViewImpl->SetDPI(dpi);
+}
+
+void
 EmbedLiteView::SetGLViewPortSize(int width, int height)
 {
   LOGNI("sz[%i,%i]", width, height);

--- a/embedding/embedlite/EmbedLiteView.h
+++ b/embedding/embedlite/EmbedLiteView.h
@@ -121,6 +121,9 @@ public:
   // Setup renderable view size
   virtual void SetViewSize(int width, int height);
 
+  // Set DPI for the view (views placed on different screens may get different DPI).
+  virtual void SetDPI(const float& dpi);
+
   // Compositor Interface
   //   PNG Decoded data
   virtual char* GetImageAsURL(int aWidth = -1, int aHeight = -1);

--- a/embedding/embedlite/PEmbedLiteView.ipdl
+++ b/embedding/embedlite/PEmbedLiteView.ipdl
@@ -102,6 +102,11 @@ parent:
     sync GetGLViewSize()
       returns (gfxSize aSize);
 
+    /*
+     * Gets the DPI of the screen corresponding to this view.
+     */
+    sync GetDPI() returns (float value);
+
     sync SyncMessage(nsString aMessage, nsString aJSON)
       returns (nsString[] retval);
 

--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -64,6 +64,7 @@ pref("apz.acceleration_multiplier", "1.125f");
 pref("apz.fling_friction", "0.00345f");
 pref("apz.min_skate_speed", "1.0f");
 pref("apz.axis_lock_mode", 2);
+pref("apz.touch_start_tolerance", "0.027777f");
 pref("ui.dragThresholdX", 25);
 pref("ui.dragThresholdY", 25);
 pref("embedlite.dispatch_mouse_events", false); // Will dispatch mouse events if page using them

--- a/embedding/embedlite/embedhelpers/EmbedLiteViewIface.idl
+++ b/embedding/embedlite/embedhelpers/EmbedLiteViewIface.idl
@@ -31,6 +31,7 @@ interface EmbedLiteViewIface
 {
     void RenderToImage(in buffer aData, in int32_t aWidth, in int32_t aHeigth, in int32_t aStride, in int32_t aDepth);
     void SetViewSize(in int32_t aWidth, in int32_t aHeight);
+    void SetDPI(in float dpi);
     void SetGLViewPortSize(in int32_t aWidth, in int32_t aHeight);
     void SetScreenRotation([const] in ScreenRotation rotation);
     void ScheduleUpdate();

--- a/embedding/embedlite/embedthread/EmbedLitePuppetWidget.cpp
+++ b/embedding/embedlite/embedthread/EmbedLitePuppetWidget.cpp
@@ -94,6 +94,7 @@ EmbedLitePuppetWidget::EmbedLitePuppetWidget(EmbedLiteViewThreadChild* aEmbed, u
   , mIMEComposing(false)
   , mParent(nullptr)
   , mId(aId)
+  , mDPI(-1.0)
 {
   MOZ_COUNT_CTOR(EmbedLitePuppetWidget);
   LOGT("this:%p", this);
@@ -466,6 +467,20 @@ EmbedLitePuppetWidget::GetGLContext() const
     }
   }
   return nullptr;
+}
+
+float
+EmbedLitePuppetWidget::GetDPI()
+{
+  if (mDPI < 0) {
+    if (mEmbed) {
+      mEmbed->SendGetDPI(&mDPI);
+    } else {
+      mDPI = nsBaseWidget::GetDPI();
+    }
+  }
+
+  return mDPI;
 }
 
 void

--- a/embedding/embedlite/embedthread/EmbedLitePuppetWidget.h
+++ b/embedding/embedlite/embedthread/EmbedLitePuppetWidget.h
@@ -154,6 +154,8 @@ public:
   virtual void CreateCompositor();
   virtual nsIntRect GetNaturalBounds();
 
+  virtual float GetDPI() MOZ_OVERRIDE;
+
   /**
    * Called before the LayerManager draws the layer tree.
    *
@@ -200,6 +202,7 @@ private:
   nsCOMPtr<nsIWidget> mParent;
 
   uint32_t mId;
+  float mDPI;
 };
 
 }  // namespace widget

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.cpp
@@ -28,6 +28,7 @@ EmbedLiteViewThreadParent::EmbedLiteViewThreadParent(const uint32_t& id, const u
   : mId(id)
   , mViewAPIDestroyed(false)
   , mCompositor(nullptr)
+  , mDPI(-1.0)
   , mRotation(ROTATION_0)
   , mPendingRotation(false)
   , mUILoop(MessageLoop::current())
@@ -85,6 +86,9 @@ EmbedLiteViewThreadParent::UpdateScrollController()
   if (mCompositor) {
     mRootLayerTreeId = mCompositor->RootLayerTreeId();
     mController->SetManagerByRootLayerTreeId(mRootLayerTreeId);
+    if (mDPI > 0) {
+      mController->GetManager()->SetDPI(mDPI);
+    }
     CompositorParent::SetControllerForLayerTree(mRootLayerTreeId, mController);
   }
 
@@ -385,10 +389,32 @@ EmbedLiteViewThreadParent::SetViewSize(int width, int height)
   return NS_OK;
 }
 
+NS_IMETHODIMP
+EmbedLiteViewThreadParent::SetDPI(float dpi)
+{
+  mDPI = dpi;
+
+  if (mController->GetManager()) {
+    mController->GetManager()->SetDPI(mDPI);
+  }
+
+  return NS_OK;
+}
+
 bool
 EmbedLiteViewThreadParent::RecvGetGLViewSize(gfxSize* aSize)
 {
   *aSize = mGLViewPortSize;
+  return true;
+}
+
+bool
+EmbedLiteViewThreadParent::RecvGetDPI(float* aValue)
+{
+  NS_ABORT_IF_FALSE(mDPI > 0,
+                    "Must not ask for DPI before View is properly initialized!");
+
+  *aValue = mDPI;
   return true;
 }
 

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.h
@@ -108,6 +108,8 @@ protected:
                                    const int32_t& aFocusChange) MOZ_OVERRIDE;
   virtual bool RecvGetGLViewSize(gfxSize* aSize) MOZ_OVERRIDE;
 
+  virtual bool RecvGetDPI(float* aValue) MOZ_OVERRIDE;
+
 private:
   friend class EmbedContentController;
   friend class EmbedLiteCompositorParent;
@@ -121,6 +123,7 @@ private:
 
   ScreenIntSize mViewSize;
   gfxSize mGLViewPortSize;
+  float mDPI;
 
   // Cache initial values.
   mozilla::ScreenRotation mRotation;


### PR DESCRIPTION
While it is possible to set DPI in EmbedlitePuppetWidget class using
the gfxPlatform::GetDPI() call this aproach doesn't seem to be plausible,
because theoretically the device may have more than one screen with different
DPI. Thus gfxPlatform::GetDPI() is not used neither in B2G nor in Metro.
Instead these two embeddings set DPI at the moment of view creation.
And their PuppetWidget works as a proxy for the real window which lives
in the UI thread. Particularly PuppetWidget forwards GetDPI() requests
from TabChild to TabParent synchrnously. And TabParent maintains its
own copy of DPI value set during window creation.

So, this commit also overrides GetDPI() for EmbedlitePuppetWidget.
First call to this methods gets forwarded synchronously to the UI thread
with the help of EmbedLiteViewThreadChild. The result is cached. After
that only cached value is returned.
