### PR TITLE
[embedlite] Refactor content size and orientation change handling. Contributes to JB#32226.

### DIFF
--- a/embedding/embedlite/EmbedLiteView.cpp
+++ b/embedding/embedlite/EmbedLiteView.cpp
@@ -281,11 +281,11 @@ EmbedLiteView::GetImageAsURL(int aWidth, int aHeight)
 }
 
 void
-EmbedLiteView::SetViewSize(int width, int height)
+EmbedLiteView::SetViewSize(int width, int height, mozilla::ScreenRotation aRotation)
 {
-  LOGNI("sz[%i,%i]", width, height);
+  LOGT("sz[%i,%i], rot:%d", width, height, aRotation);
   NS_ENSURE_TRUE(mViewImpl, );
-  mViewImpl->SetViewSize(width, height);
+  mViewImpl->SetViewSize(width, height, aRotation);
 }
 
 void
@@ -302,14 +302,6 @@ EmbedLiteView::SetGLViewPortSize(int width, int height)
   NS_ENSURE_TRUE(mViewImpl, );
   mViewImpl->SetGLViewPortSize(width, height);
 }
-
-void
-EmbedLiteView::SetScreenRotation(mozilla::ScreenRotation rotation)
-{
-  NS_ENSURE_TRUE(mViewImpl, );
-  mViewImpl->SetScreenRotation(rotation);
-}
-
 
 void
 EmbedLiteView::ScheduleUpdate()

--- a/embedding/embedlite/EmbedLiteView.h
+++ b/embedding/embedlite/EmbedLiteView.h
@@ -79,6 +79,11 @@ public:
 
   // Will be always called from the compositor thread.
   virtual void DrawOverlay(const nsIntRect& aRect) {}
+
+  // Invoked when expensive content rotation operation starts/ends. Not triggered
+  // for cheap and fast content rotation changes (ex, landscape->inverted landscape).
+  virtual void ContentRotationStarted() {}
+  virtual void ContentRotationFinished() {}
 };
 
 class EmbedLiteApp;
@@ -119,7 +124,7 @@ public:
   virtual void PinchEnd(int x, int y, float scale);
 
   // Setup renderable view size
-  virtual void SetViewSize(int width, int height);
+  virtual void SetViewSize(int width, int height, mozilla::ScreenRotation rotation);
 
   // Set DPI for the view (views placed on different screens may get different DPI).
   virtual void SetDPI(const float& dpi);
@@ -133,9 +138,6 @@ public:
 
   //   Setup renderable GL/EGL window surface size
   virtual void SetGLViewPortSize(int width, int height);
-
-  // Set screen rotation (orientation change).
-  virtual void SetScreenRotation(mozilla::ScreenRotation rotation);
 
   virtual void ScheduleUpdate();
   // Clear the content of the view compositing surface with a given color.

--- a/embedding/embedlite/Makefile.in
+++ b/embedding/embedlite/Makefile.in
@@ -12,6 +12,7 @@ LOCAL_INCLUDES += \
     -I$(topsrcdir)/dom/ipc \
     -I$(topsrcdir)/js/xpconnect/src \
     -I$(topsrcdir)/gfx/layers/apz/util \
+    -I$(topsrcdir)/hal \
     $(NULL)
 
 DEFINES += -DEMBED_LITE_INTERNAL=1

--- a/embedding/embedlite/PEmbedLiteView.ipdl
+++ b/embedding/embedlite/PEmbedLiteView.ipdl
@@ -4,6 +4,7 @@
 
 include protocol PEmbedLiteApp;
 
+include "gfxipc/ShadowLayerUtils.h";
 include "ipc/nsGUIEventIPC.h";
 include "ipc/InputDataIPC.h";
 include "mozilla/GfxMessageUtils.h";
@@ -23,6 +24,7 @@ using class mozilla::WidgetMouseEvent from "ipc/nsGUIEventIPC.h";
 using MultiTouchInput from "InputData.h";
 using mozilla::CSSIntPoint from "Units.h";
 using struct mozilla::layers::ZoomConstraints from "FrameMetrics.h";
+using mozilla::ScreenRotation from "mozilla/WidgetUtils.h";
 
 namespace mozilla {
 namespace embedlite {
@@ -36,7 +38,7 @@ child:
     StopLoad();
     Reload(bool hardReload);
     LoadFrameScript(nsString uri);
-    SetViewSize(gfxSize aSize);
+    SetViewSize(gfxSize aSize, ScreenRotation aRotation);
     SetGLViewSize(gfxSize aSize);
     SetIsActive(bool aIsActive);
     SetIsFocused(bool aIsFocused);
@@ -83,6 +85,10 @@ parent:
     OnScrollChanged(int32_t offSetX, int32_t offSetY);
     OnTitleChanged(nsString aTitle);
     OnWindowCloseRequested();
+
+    AckSetViewSize(gfxSize aSize, ScreenRotation aRotation);
+    SizeChangeReflowStarted();
+    SizeChangeReflowFinished();
 
     /**
      * Updates the zoom constraints for a scrollable frame in this tab.

--- a/embedding/embedlite/embedhelpers/EmbedLiteViewIface.idl
+++ b/embedding/embedlite/embedhelpers/EmbedLiteViewIface.idl
@@ -30,10 +30,9 @@ class nsString;
 interface EmbedLiteViewIface
 {
     void RenderToImage(in buffer aData, in int32_t aWidth, in int32_t aHeigth, in int32_t aStride, in int32_t aDepth);
-    void SetViewSize(in int32_t aWidth, in int32_t aHeight);
+    void SetViewSize(in int32_t aWidth, in int32_t aHeight, in ScreenRotation aRotation);
     void SetDPI(in float dpi);
     void SetGLViewPortSize(in int32_t aWidth, in int32_t aHeight);
-    void SetScreenRotation([const] in ScreenRotation rotation);
     void ScheduleUpdate();
     void ReceiveInputEvent([const] in InputData aEvent);
     void TextEvent(in string aComposite, in string aPreEdit);

--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
@@ -36,8 +36,6 @@ public:
   bool RenderToContext(gfx::DrawTarget* aTarget);
   bool RenderGL();
   void SetSurfaceSize(int width, int height);
-  void SetScreenRotation(const mozilla::ScreenRotation& rotation);
-  void SetClipping(const gfxRect& aClipRect);
   void* GetPlatformImage(int* width, int* height);
   void SuspendRendering();
   void ResumeRendering();
@@ -64,10 +62,6 @@ private:
   static void ClearCompositorSurfaceImpl(mozilla::gl::GLContext*, nscolor);
 
   uint32_t mId;
-  gfx::Matrix mWorldTransform;
-  mozilla::ScreenRotation mRotation;
-  bool mUseScreenRotation;
-  nsIntRect mActiveClipping;
   CancelableTask* mCurrentCompositeTask;
   gfx::IntSize mLastViewSize;
   short mInitialPaintCount;

--- a/embedding/embedlite/embedthread/EmbedLitePuppetWidget.h
+++ b/embedding/embedlite/embedthread/EmbedLitePuppetWidget.h
@@ -104,10 +104,7 @@ public:
     LOGNI();
     return NS_OK;
   }
-  NS_IMETHOD Invalidate(const nsIntRect& aRect) {
-    return NS_OK;
-  }
-  // PuppetWidgets don't have native data, as they're purely nonnative.
+  NS_IMETHOD Invalidate(const nsIntRect& aRect) override;
   virtual void* GetNativeData(uint32_t aDataType);
   // PuppetWidgets don't have any concept of titles..
   NS_IMETHOD SetTitle(const nsAString& aTitle) {
@@ -152,7 +149,7 @@ public:
   virtual mozilla::layers::CompositorParent* NewCompositorParent(int aSurfaceWidth, int aSurfaceHeight) MOZ_OVERRIDE;
   virtual void CreateCompositor(int aWidth, int aHeight);
   virtual void CreateCompositor();
-  virtual nsIntRect GetNaturalBounds();
+  virtual nsIntRect GetNaturalBounds() MOZ_OVERRIDE;
 
   virtual float GetDPI() MOZ_OVERRIDE;
 
@@ -162,7 +159,7 @@ public:
    * Always called from the compositing thread. Puppet Widget passes the call
    * forward to the EmbedLiteCompositorParent.
    */
-  virtual void DrawWindowUnderlay(LayerManagerComposite* aManager, nsIntRect aRect);
+  virtual void DrawWindowUnderlay(LayerManagerComposite* aManager, nsIntRect aRect) MOZ_OVERRIDE;
 
 
   /**
@@ -171,17 +168,25 @@ public:
    * Always called from the compositing thread. Puppet Widget passes the call
    * forward to the EmbedLiteCompositorParent.
    */
-  virtual void DrawWindowOverlay(LayerManagerComposite* aManager, nsIntRect aRect);
+  virtual void DrawWindowOverlay(LayerManagerComposite* aManager, nsIntRect aRect) MOZ_OVERRIDE;
 
-  virtual bool PreRender(LayerManagerComposite* aManager) override;
+  virtual bool PreRender(LayerManagerComposite* aManager) MOZ_OVERRIDE;
+  virtual void PostRender(LayerManagerComposite *aManager) MOZ_OVERRIDE;
 
   NS_IMETHOD         SetParent(nsIWidget* aNewParent);
   virtual nsIWidget *GetParent(void);
+
+  void SetRotation(mozilla::ScreenRotation);
+  void SetNaturalBounds(const nsIntRect&);
+  void UpdateCompositorSurfaceSize();
+  void SetReflowInProgress(bool reflow);
 
 protected:
   virtual ~EmbedLitePuppetWidget();
 
 private:
+  typedef nsTArray<EmbedLitePuppetWidget*> ChildrenArray;
+
   nsresult Paint();
   bool ViewIsValid();
   mozilla::gl::GLContext* GetGLContext() const;
@@ -198,8 +203,11 @@ private:
   InputContext mInputContext;
   bool mIMEComposing;
   nsString mIMEComposingText;
-  nsRefPtr<EmbedLitePuppetWidget> mChild;
-  nsCOMPtr<nsIWidget> mParent;
+  ChildrenArray mChildren;
+  EmbedLitePuppetWidget* mParent;
+  mozilla::ScreenRotation mRotation;
+  nsIntRect mNaturalBounds;
+  bool mReflowInProgress;
 
   uint32_t mId;
   float mDPI;

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.h
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.h
@@ -77,7 +77,7 @@ protected:
   virtual bool RecvSuspendTimeouts() MOZ_OVERRIDE;
   virtual bool RecvResumeTimeouts() MOZ_OVERRIDE;
   virtual bool RecvLoadFrameScript(const nsString&) MOZ_OVERRIDE;
-  virtual bool RecvSetViewSize(const gfxSize&) MOZ_OVERRIDE;
+  virtual bool RecvSetViewSize(const gfxSize&, const mozilla::ScreenRotation&) MOZ_OVERRIDE;
   virtual bool RecvAsyncScrollDOMEvent(const gfxRect& contentRect,
                                        const gfxSize& scrollSize) MOZ_OVERRIDE;
 
@@ -125,6 +125,7 @@ private:
   void InitGeckoWindow(const uint32_t& parentId, const bool& isPrivateWindow);
   EmbedLiteAppThreadChild* AppChild();
   void InitEvent(WidgetGUIEvent& event, nsIntPoint* aPoint = nullptr);
+  void UpdateDOMOrientation(const mozilla::ScreenRotation);
 
   uint32_t mId;
   uint64_t mOuterId;
@@ -135,7 +136,9 @@ private:
   nsCOMPtr<nsIWebNavigation> mWebNavigation;
   gfxSize mViewSize;
   bool mViewResized;
+  bool mSizeReflowInProgress;
   gfxSize mGLViewSize;
+  mozilla::ScreenRotation mRotation;
 
   nsRefPtr<TabChildHelper> mHelper;
   bool mDispatchSynthMouseEvents;

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.h
@@ -107,6 +107,9 @@ protected:
                                    const int32_t& aCause,
                                    const int32_t& aFocusChange) MOZ_OVERRIDE;
   virtual bool RecvGetGLViewSize(gfxSize* aSize) MOZ_OVERRIDE;
+  virtual bool RecvAckSetViewSize(const gfxSize&, const mozilla::ScreenRotation&) MOZ_OVERRIDE;
+  virtual bool RecvSizeChangeReflowStarted();
+  virtual bool RecvSizeChangeReflowFinished();
 
   virtual bool RecvGetDPI(float* aValue) MOZ_OVERRIDE;
 
@@ -121,13 +124,15 @@ private:
   bool mViewAPIDestroyed;
   RefPtr<EmbedLiteCompositorParent> mCompositor;
 
-  ScreenIntSize mViewSize;
+  gfxSize mViewSize;
   gfxSize mGLViewPortSize;
   float mDPI;
 
   // Cache initial values.
   mozilla::ScreenRotation mRotation;
-  bool mPendingRotation;
+  bool mViewSizeChangeScheduled;
+  bool mRotationChangedRecently;
+  bool mRotationStartedEventSent;
 
   MessageLoop* mUILoop;
   int mLastIMEState;

--- a/embedding/embedlite/tests/embedLiteViewInitTest.cpp
+++ b/embedding/embedlite/tests/embedLiteViewInitTest.cpp
@@ -6,6 +6,7 @@
 #include "mozilla/embedlite/EmbedInitGlue.h"
 #include "mozilla/embedlite/EmbedLiteApp.h"
 #include "mozilla/embedlite/EmbedLiteView.h"
+#include "mozilla/WidgetUtils.h"
 #include "qmessagepump.h"
 #include <list>
 
@@ -63,7 +64,7 @@ public:
     printf("Embedding has created view:%p, Yay\n", mView);
     // FIXME if resize is not called,
     // then Widget/View not initialized properly and prevent destroy process
-    mView->SetViewSize(800, 600);
+    mView->SetViewSize(800, 600, mozilla::ROTATION_0);
     mView->LoadURL("data:text/html,<body bgcolor=red>TestApp</body>");
   }
   virtual void ViewDestroyed() {

--- a/embedding/embedlite/utils/TabChildHelper.cpp
+++ b/embedding/embedlite/utils/TabChildHelper.cpp
@@ -491,7 +491,7 @@ TabChildHelper::DoUpdateZoomConstraints(const uint32_t& aPresShellId,
                                           aConstraints);
 }
 
-void
+bool
 TabChildHelper::ReportSizeUpdate(const gfxSize& aSize)
 {
   bool initialSizing = !HasValidInnerSize()
@@ -500,8 +500,12 @@ TabChildHelper::ReportSizeUpdate(const gfxSize& aSize)
     mHasValidInnerSize = true;
   }
 
+  float oldViewportWidth = mLastRootMetrics.GetViewport().width;
+
   ScreenIntSize oldScreenSize(mInnerSize);
   mInnerSize = ScreenIntSize::FromUnknownSize(gfx::IntSize(aSize.width, aSize.height));
 
   HandlePossibleViewportChange(oldScreenSize);
+
+  return oldViewportWidth != mLastRootMetrics.GetViewport().width;
 }

--- a/embedding/embedlite/utils/TabChildHelper.h
+++ b/embedding/embedlite/utils/TabChildHelper.h
@@ -60,7 +60,7 @@ public:
                                        const mozilla::layers::FrameMetrics::ViewID& aViewId,
                                        const bool& aIsRoot,
                                        const mozilla::layers::ZoomConstraints& aConstraints) MOZ_OVERRIDE;
-  void ReportSizeUpdate(const gfxSize& aSize);
+  bool ReportSizeUpdate(const gfxSize& aSize);
 
 protected:
   virtual ~TabChildHelper();


### PR DESCRIPTION
Many of the ideas implemented by this patch have been taken from my
previous work on the same feature in gecko v38. Basically the rotation
handling is moved entirely to the gecko widget layer. This closely
reassembles what B2G/Gonk is doing. V31 is a bit different in some
regards from v38, but it's close enough.

The main differences from the current v38 work is in unification of size
and rotation change handling. The main problem with rotation and size
changes is in the fact that TabChildBase::HandlePossileViewportChange is
an expensive function to call. We need to call it always when the width
of the viewport might have changed. This can obsiously happen in case
the window is resized (desktop mostly) or rotated. To minimize the
amount of necessary TabChildBase::HandlePossibleViewportChange calls
size and rotation changes were merged into one function. Additionally,
each view dimension change has to be acked by the view child. This
allows the parent to drop pending size requests which have been
invalidated. In previous architecture if the embedder changed view size
quickly 5 times, all the requests were queued and processed (triggering
expensive viewport update 5 times). In the new arch in most cases onl
first and last requests will be processed.

To allow application to show some sort of placeholder when potential
expensive rotation/viewport width change is processed some additional
view notifications have been introduced.
